### PR TITLE
stringify and escape jwt options before sending to generator

### DIFF
--- a/test/vc-data-model-1.0/util.js
+++ b/test/vc-data-model-1.0/util.js
@@ -18,8 +18,9 @@ async function generate(file, options) {
 
 async function generateJwt(file, options) {
   options = options || {};
-  const {stdout, stderr} = await exec(options.generator + ' ' +
-    options.jwt + ' ' + path.join(__dirname, 'input', file));
+  const {stdout, stderr} = await exec(options.generator +
+   ' "' + JSON.stringify(options.jwt).replace(/"/g, "\\\"") + '" '+
+   path.join(__dirname, 'input', file));
 
   if(stderr) {
     throw new Error(stderr);


### PR DESCRIPTION
with this change, the test suite outputs the serialized and escaped JSON to the exec command instead of `[object Object]`